### PR TITLE
Added Windows support by using "cmd /c" on Windows platform

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,31 @@ jobs:
       - run: cargo build-all-features
       - run: cargo build-all-features --release
 
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo install cargo-all-features
+      - run: cargo build-all-features
+      - run: cargo build-all-features --release
+
   test:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo install cargo-all-features
+      - run: cargo install mdbook
+      - run: cargo test-all-features
+      - run: cargo test-all-features --release
+
+  test-windows:
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,18 +52,6 @@ jobs:
       - run: cargo test-all-features
       - run: cargo test-all-features --release
 
-  test-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - run: cargo install cargo-all-features
-      - run: cargo install mdbook
-      - run: cargo test-all-features
-      - run: cargo test-all-features --release
-
   check_readme:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ When the pattern `<!-- cmdrun $1 -->\n` is encountered, the command `$1` will be
 Also the working directory is the directory where the pattern was found (not root).
 The command invoked must take no inputs (stdin is not used), but a list of command lines arguments and must produce output in stdout, stderr is ignored.
 
+As of July 2023 runs on Windows platforms via using the `cmd` shell!
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ When the pattern `<!-- cmdrun $1 -->\n` is encountered, the command `$1` will be
 Also the working directory is the directory where the pattern was found (not root).
 The command invoked must take no inputs (stdin is not used), but a list of command lines arguments and must produce output in stdout, stderr is ignored.
 
-WARNING: This method only works with any system that has a shell `sh` that rust can find. Windows is not supported for now, see [here](https://github.com/FauconFan/mdbook-cmdrun/issues/5) for more.
-
 ## Examples
 
 The following is valid:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ When the pattern `<!-- cmdrun $1 -->\n` is encountered, the command `$1` will be
 Also the working directory is the directory where the pattern was found (not root).
 The command invoked must take no inputs (stdin is not used), but a list of command lines arguments and must produce output in stdout, stderr is ignored.
 
+
 ## Examples
 
 The following is valid:

--- a/src/cmdrun.rs
+++ b/src/cmdrun.rs
@@ -15,6 +15,16 @@ use crate::utils::map_chapter;
 
 pub struct CmdRun;
 
+#[cfg(not(windows))]
+const LAUNCH_SHELL_COMMAND: &str = "sh";
+#[cfg(not(windows))]
+const LAUNCH_SHELL_FLAG: &str = "-c";
+
+#[cfg(windows)]
+const LAUNCH_SHELL_COMMAND: &str = "cmd";
+#[cfg(windows)]
+const LAUNCH_SHELL_FLAG: &str = "/c";
+
 impl Preprocessor for CmdRun {
     fn name(&self) -> &str {
         "cmdrun"
@@ -77,8 +87,8 @@ impl CmdRun {
 
     // This method is public for unit tests
     pub fn run_cmdrun(command: String, working_dir: &str) -> Result<String> {
-        let output = Command::new("sh")
-            .args(["-c", &command])
+        let output = Command::new(LAUNCH_SHELL_COMMAND)
+            .args([LAUNCH_SHELL_FLAG, &command])
             .current_dir(working_dir)
             .output()
             .with_context(|| "Fail to run shell")?;

--- a/src/cmdrun.rs
+++ b/src/cmdrun.rs
@@ -15,14 +15,14 @@ use crate::utils::map_chapter;
 
 pub struct CmdRun;
 
-#[cfg(not(windows))]
+#[cfg(any(target_family = "unix", target_family = "other"))]
 const LAUNCH_SHELL_COMMAND: &str = "sh";
-#[cfg(not(windows))]
+#[cfg(any(target_family = "unix", target_family = "other"))]
 const LAUNCH_SHELL_FLAG: &str = "-c";
 
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 const LAUNCH_SHELL_COMMAND: &str = "cmd";
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 const LAUNCH_SHELL_FLAG: &str = "/c";
 
 impl Preprocessor for CmdRun {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@
 //! Also the working directory is the directory where the pattern was found (not root).
 //! The command invoked must take no inputs (stdin is not used), but a list of command lines arguments and must produce output in stdout, stderr is ignored.
 //!
-//! WARNING: This method only works with any system that has a shell `sh` that rust can find. Windows is not supported for now, see [here](https://github.com/FauconFan/mdbook-cmdrun/issues/5) for more.
 //!
 //! # Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 //! Also the working directory is the directory where the pattern was found (not root).
 //! The command invoked must take no inputs (stdin is not used), but a list of command lines arguments and must produce output in stdout, stderr is ignored.
 //!
+//! As of July 2023 runs on Windows platforms via using the `cmd` shell!
 //!
 //! # Examples
 //!


### PR DESCRIPTION
# Issue https://github.com/FauconFan/mdbook-cmdrun/issues/5
Currently Cmdrun can't be used on Windows due to using `sh` when launching the command, this fixes that by adding some constants that are evaluated at compilation time and using those to launch the command instead.

Currently, the tests are broken on Windows if not running via WSL due to linebreaks, `\r\n` vs `\n`, I was thinking about fixing it but it would require changing your macro and I do not have the confidence in my Rust macro skills to do so.
