### PR TITLE
add ability to check exit status of command that was run

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,39 @@ At the moment of writing, there are examples using:
 - Node
 - Rust
 
+Often, it is helpful to ensure that the commands being run successfully complete
+or at least return the expected exit code. This check is supported through an
+optional flag after `cmdrun` but before your command.
+Any errors encountered by cmdrun are reported in the rendered mdbook.
+For example, the following source
+
+````markdown
+<!-- cmdrun -0 echo hello world -->
+```diff
+<!-- cmdrun -0 diff a.rs b.rs -->
+```
+```diff
+<!-- cmdrun -1 diff a.rs b.rs -->
+```
+````
+gets rendered as
+````markdown
+hello world
+```diff
+**cmdrun error**: 'diff a.rs b.rs' returned exit code 1 instead of 0.
+```
+```diff
+2c2
+<    println!("I'm from `a.rs`");
+---
+>    println!("I'm from `b.rs`");
+```
+````
+The available flags for specifying the exit code are
+- `-N` where `N` is the integer exit code that the command should return
+- `--strict` requires the command to return 0
+- `--expect-return-code N` requires the command to return code `N`
+
 
 ## Contributors
 

--- a/src/cmdrun.rs
+++ b/src/cmdrun.rs
@@ -162,7 +162,10 @@ impl CmdRun {
         let (command, correct_exit_code): (String, Option<i32>) = if let Some(first_word) = command.split_whitespace().next() {
             if first_word.starts_with('-') {
                 let (_, exit_code) = first_word.rsplit_once('-').unwrap_or(("","0"));
-                (command.split_whitespace().skip(1).collect::<String>(), Some(exit_code.parse()?))
+                (
+                    command.split_whitespace().skip(1).collect::<Vec<&str>>().join(" "),
+                    Some(exit_code.parse()?)
+                )
             } else {
                 (command, None)
             }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -44,36 +44,6 @@ cfg_if! {
         add_test!(quote3, "echo ''", "\n", false);
         add_test!(quote4, "echo '\\'", "\\\n", false);
 
-        // the inline flag only affects the output and here I'm just checking exit codes
-        // so I only test without the inline flag
-        add_test!(pass_without_exit_code_spec, "exit 1", "", false);
-        add_test!(short_match_fail_exit_code, "-1 exit 1", "", false);
-        add_test!(short_match_pass_exit_code, "-0 exit 0", "", false);
-        add_test!(short_exit_code_mismatch, "-0 exit 1",
-                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
-        add_test!(long_match_fail_exit_code, "--expect-return-code 1 exit 1", "", false);
-        add_test!(long_match_pass_exit_code1, "--expect-return-code 0 exit 0", "", false);
-        add_test!(long_match_pass_exit_code2, "--strict exit 0", "", false);
-        add_test!(long_exit_code_mismatch1, "--expect-return-code 0 exit 1",
-                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
-        add_test!(long_exit_code_mismatch2, "--strict exit 1",
-                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
-        add_test!(not_a_cmdrun_flag, "--flag-dne echo hello world",
-                  "**cmdrun error**: Unrecognized cmdrun flag --flag-dne in 'cmdrun --flag-dne echo hello world'",
-                  false);
-        add_test!(shortform_typo, "--0 echo hello world",
-                  "**cmdrun error**: Unrecognized cmdrun flag --0 in 'cmdrun --0 echo hello world'",
-                  false);
-        add_test!(missing_arg_no_cmd, "--expect-return-code",
-                  "**cmdrun error**: No return code after '--expect-return-code' in 'cmdrun --expect-return-code'",
-                  false);
-        add_test!(missing_arg_no_code, "--expect-return-code echo hello world",
-                  "**cmdrun error**: No return code after '--expect-return-code' in 'cmdrun --expect-return-code echo hello world'",
-                  false);
-        add_test!(bad_short_form_exit_code, "-NaN echo hello world",
-                  "**cmdrun error**: Unable to interpret short-form exit code -NaN as a number in 'cmdrun -NaN echo hello world'",
-                  false);
-
         add_test!(
             mixed_inline1,
             "yes 42 | head -n 4 | sed -z 's/\\n/  \\n/g'",
@@ -118,20 +88,37 @@ cfg_if! {
             "42  \r\n42  \r\n42  \r\n42  \r\n", false
             );
 
-        // the inline flag only affects the output and here I'm just checking exit codes
-        // so I only test without the inline flag
-        add_test!(pass_without_exit_code_spec, "exit 1", "", false);
-        add_test!(short_match_fail_exit_code, "-1 exit 1", "", false);
-        add_test!(short_match_pass_exit_code, "-0 exit 0", "", false);
-        add_test!(short_exit_code_mismatch, "-0 exit 1",
-                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
-        add_test!(long_match_fail_exit_code, "--expect-return-code 1 exit 1", "", false);
-        add_test!(long_match_pass_exit_code1, "--expect-return-code 0 exit 0", "", false);
-        add_test!(long_match_pass_exit_code2, "--strict exit 0", "", false);
-        add_test!(long_exit_code_mismatch1, "--expect-return-code 0 exit 1",
-                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
-        add_test!(long_exit_code_mismatch2, "--strict exit 1",
-                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
-
     }
 }
+
+// the inline flag only affects the output and here I'm just checking exit codes
+// so I only test without the inline flag
+// I am also not testing more complicated input/output strings and so it is
+// the same between Windoze and Unix
+add_test!(pass_without_exit_code_spec, "exit 1", "", false);
+add_test!(short_match_fail_exit_code, "-1 exit 1", "", false);
+add_test!(short_match_pass_exit_code, "-0 exit 0", "", false);
+add_test!(short_exit_code_mismatch, "-0 exit 1",
+          "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
+add_test!(long_match_fail_exit_code, "--expect-return-code 1 exit 1", "", false);
+add_test!(long_match_pass_exit_code1, "--expect-return-code 0 exit 0", "", false);
+add_test!(long_match_pass_exit_code2, "--strict exit 0", "", false);
+add_test!(long_exit_code_mismatch1, "--expect-return-code 0 exit 1",
+          "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
+add_test!(long_exit_code_mismatch2, "--strict exit 1",
+          "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
+add_test!(not_a_cmdrun_flag, "--flag-dne echo hello world",
+          "**cmdrun error**: Unrecognized cmdrun flag --flag-dne in 'cmdrun --flag-dne echo hello world'",
+          false);
+add_test!(shortform_typo, "--0 echo hello world",
+          "**cmdrun error**: Unrecognized cmdrun flag --0 in 'cmdrun --0 echo hello world'",
+          false);
+add_test!(missing_arg_no_cmd, "--expect-return-code",
+          "**cmdrun error**: No return code after '--expect-return-code' in 'cmdrun --expect-return-code'",
+          false);
+add_test!(missing_arg_no_code, "--expect-return-code echo hello world",
+          "**cmdrun error**: No return code after '--expect-return-code' in 'cmdrun --expect-return-code echo hello world'",
+          false);
+add_test!(bad_short_form_exit_code, "-NaN echo hello world",
+          "**cmdrun error**: Unable to interpret short-form exit code -NaN as a number in 'cmdrun -NaN echo hello world'",
+          false);

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -44,6 +44,16 @@ cfg_if! {
         add_test!(quote3, "echo ''", "\n", false);
         add_test!(quote4, "echo '\\'", "\\\n", false);
 
+        #[test]
+        fn fail_inline() {
+            assert!(CmdRun::run_cmdrun("-1 exit 1".to_string(), ".", true).is_err())
+        }
+
+        #[test]
+        fn fail() {
+            assert!(CmdRun::run_cmdrun("-1 exit 1".to_string(), ".", false).is_err())
+        }
+
         add_test!(
             mixed_inline1,
             "yes 42 | head -n 4 | sed -z 's/\\n/  \\n/g'",

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -44,14 +44,19 @@ cfg_if! {
         add_test!(quote3, "echo ''", "\n", false);
         add_test!(quote4, "echo '\\'", "\\\n", false);
 
+        // the inline flag only affects the output and here I'm just checking exit codes
+        // so I only test without the inline flag
+        add_test!(match_fail_exit_code, "-1 exit 1", "", false);
+        add_test!(match_pass_exit_code, "-0 exit 0", "", false);
+
         #[test]
-        fn fail_inline() {
-            assert!(CmdRun::run_cmdrun("-1 exit 1".to_string(), ".", true).is_err())
+        fn exit_code_mismatch() {
+            assert!(CmdRun::run_cmdrun("-0 exit 1".to_string(), ".", false).is_err())
         }
 
         #[test]
-        fn fail() {
-            assert!(CmdRun::run_cmdrun("-1 exit 1".to_string(), ".", false).is_err())
+        fn bad_exit_code_spec() {
+            assert!(CmdRun::run_cmdrun("-O exit 0".to_string(), ".", false).is_err())
         }
 
         add_test!(

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -46,19 +46,18 @@ cfg_if! {
 
         // the inline flag only affects the output and here I'm just checking exit codes
         // so I only test without the inline flag
-        add_test!(match_fail_exit_code, "-1 exit 1", "", false);
-        add_test!(match_pass_exit_code, "-0 exit 0", "", false);
         add_test!(pass_without_exit_code_spec, "exit 1", "", false);
-
-        #[test]
-        fn exit_code_mismatch() {
-            assert!(CmdRun::run_cmdrun("-0 exit 1".to_string(), ".", false).is_err())
-        }
-
-        #[test]
-        fn bad_exit_code_spec() {
-            assert!(CmdRun::run_cmdrun("-O exit 0".to_string(), ".", false).is_err())
-        }
+        add_test!(short_match_fail_exit_code, "-1 exit 1", "", false);
+        add_test!(short_match_pass_exit_code, "-0 exit 0", "", false);
+        add_test!(short_exit_code_mismatch, "-0 exit 1",
+                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
+        add_test!(long_match_fail_exit_code, "--expect-return-code 1 exit 1", "", false);
+        add_test!(long_match_pass_exit_code1, "--expect-return-code 0 exit 0", "", false);
+        add_test!(long_match_pass_exit_code2, "--strict exit 0", "", false);
+        add_test!(long_exit_code_mismatch1, "--expect-return-code 0 exit 1",
+                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
+        add_test!(long_exit_code_mismatch2, "--strict exit 1",
+                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
 
         add_test!(
             mixed_inline1,
@@ -103,6 +102,21 @@ cfg_if! {
             "yes 42 | head -n 4 | sed -z 's/\\n/  \\n/g'",
             "42  \r\n42  \r\n42  \r\n42  \r\n", false
             );
+
+        // the inline flag only affects the output and here I'm just checking exit codes
+        // so I only test without the inline flag
+        add_test!(pass_without_exit_code_spec, "exit 1", "", false);
+        add_test!(short_match_fail_exit_code, "-1 exit 1", "", false);
+        add_test!(short_match_pass_exit_code, "-0 exit 0", "", false);
+        add_test!(short_exit_code_mismatch, "-0 exit 1",
+                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
+        add_test!(long_match_fail_exit_code, "--expect-return-code 1 exit 1", "", false);
+        add_test!(long_match_pass_exit_code1, "--expect-return-code 0 exit 0", "", false);
+        add_test!(long_match_pass_exit_code2, "--strict exit 0", "", false);
+        add_test!(long_exit_code_mismatch1, "--expect-return-code 0 exit 1",
+                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
+        add_test!(long_exit_code_mismatch2, "--strict exit 1",
+                  "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
 
     }
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -48,6 +48,7 @@ cfg_if! {
         // so I only test without the inline flag
         add_test!(match_fail_exit_code, "-1 exit 1", "", false);
         add_test!(match_pass_exit_code, "-0 exit 0", "", false);
+        add_test!(pass_without_exit_code_spec, "exit 1", "", false);
 
         #[test]
         fn exit_code_mismatch() {

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -98,21 +98,49 @@ cfg_if! {
 add_test!(pass_without_exit_code_spec, "exit 1", "", false);
 add_test!(short_match_fail_exit_code, "-1 exit 1", "", false);
 add_test!(short_match_pass_exit_code, "-0 exit 0", "", false);
-add_test!(short_exit_code_mismatch, "-0 exit 1",
-          "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
-add_test!(long_match_fail_exit_code, "--expect-return-code 1 exit 1", "", false);
-add_test!(long_match_pass_exit_code1, "--expect-return-code 0 exit 0", "", false);
+add_test!(
+    short_exit_code_mismatch,
+    "-0 exit 1",
+    "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n",
+    false
+);
+add_test!(
+    long_match_fail_exit_code,
+    "--expect-return-code 1 exit 1",
+    "",
+    false
+);
+add_test!(
+    long_match_pass_exit_code1,
+    "--expect-return-code 0 exit 0",
+    "",
+    false
+);
 add_test!(long_match_pass_exit_code2, "--strict exit 0", "", false);
-add_test!(long_exit_code_mismatch1, "--expect-return-code 0 exit 1",
-          "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
-add_test!(long_exit_code_mismatch2, "--strict exit 1",
-          "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
-add_test!(not_a_cmdrun_flag, "--flag-dne echo hello world",
-          "**cmdrun error**: Unrecognized cmdrun flag --flag-dne in 'cmdrun --flag-dne echo hello world'",
-          false);
-add_test!(shortform_typo, "--0 echo hello world",
-          "**cmdrun error**: Unrecognized cmdrun flag --0 in 'cmdrun --0 echo hello world'",
-          false);
+add_test!(
+    long_exit_code_mismatch1,
+    "--expect-return-code 0 exit 1",
+    "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n",
+    false
+);
+add_test!(
+    long_exit_code_mismatch2,
+    "--strict exit 1",
+    "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n",
+    false
+);
+add_test!(
+    not_a_cmdrun_flag,
+    "--flag-dne echo hello world",
+    "**cmdrun error**: Unrecognized cmdrun flag --flag-dne in 'cmdrun --flag-dne echo hello world'",
+    false
+);
+add_test!(
+    shortform_typo,
+    "--0 echo hello world",
+    "**cmdrun error**: Unrecognized cmdrun flag --0 in 'cmdrun --0 echo hello world'",
+    false
+);
 add_test!(missing_arg_no_cmd, "--expect-return-code",
           "**cmdrun error**: No return code after '--expect-return-code' in 'cmdrun --expect-return-code'",
           false);

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -58,6 +58,18 @@ cfg_if! {
                   "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
         add_test!(long_exit_code_mismatch2, "--strict exit 1",
                   "**cmdrun error**: 'exit 1' returned exit code 1 instead of 0.\n\n", false);
+        add_test!(not_a_cmdrun_flag, "--flag-dne echo hello world",
+                  "**cmdrun error**: Unrecognized cmdrun flag --flag-dne in 'cmdrun --flag-dne echo hello world'",
+                  false);
+        add_test!(missing_arg_no_cmd, "--expect-return-code",
+                  "**cmdrun error**: No return code after '--expect-return-code' in 'cmdrun --expect-return-code'",
+                  false);
+        add_test!(missing_arg_no_code, "--expect-return-code echo hello world",
+                  "**cmdrun error**: No return code after '--expect-return-code' in 'cmdrun --expect-return-code echo hello world'",
+                  false);
+        add_test!(bad_short_form_exit_code, "-NaN echo hello world",
+                  "**cmdrun error**: Unable to interpret short-form exit code -NaN as a number in 'cmdrun -NaN echo hello world'",
+                  false);
 
         add_test!(
             mixed_inline1,

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -61,6 +61,9 @@ cfg_if! {
         add_test!(not_a_cmdrun_flag, "--flag-dne echo hello world",
                   "**cmdrun error**: Unrecognized cmdrun flag --flag-dne in 'cmdrun --flag-dne echo hello world'",
                   false);
+        add_test!(shortform_typo, "--0 echo hello world",
+                  "**cmdrun error**: Unrecognized cmdrun flag --0 in 'cmdrun --0 echo hello world'",
+                  false);
         add_test!(missing_arg_no_cmd, "--expect-return-code",
                   "**cmdrun error**: No return code after '--expect-return-code' in 'cmdrun --expect-return-code'",
                   false);

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -73,6 +73,7 @@ fn check_all_regressions_dirs() {
         entries,
         vec![
             "bash_call",
+            "err_messages",
             "inline_call",
             "py_factorial",
             "py_fibonacci",
@@ -90,3 +91,4 @@ add_dir!(py_factorial);
 add_dir!(py_fibonacci);
 add_dir!(rust_call);
 add_dir!(shell);
+add_dir!(err_messages);

--- a/tests/regression/err_messages/input.md
+++ b/tests/regression/err_messages/input.md
@@ -1,0 +1,7 @@
+# Error Messages
+
+<!-- cmdrun --0 echo simple typo -->
+
+<!-- cmdrun eco simple typo that will inject empty line -->
+
+<!-- cmdrun -0 eco simple typo that will now inject error message -->

--- a/tests/regression/err_messages/input_win.md
+++ b/tests/regression/err_messages/input_win.md
@@ -1,0 +1,1 @@
+input.md

--- a/tests/regression/err_messages/output.md
+++ b/tests/regression/err_messages/output.md
@@ -1,0 +1,7 @@
+# Error Messages
+
+**cmdrun error**: Unrecognized cmdrun flag --0 in 'cmdrun --0 echo simple typo '
+
+**cmdrun error**: 'eco simple typo that will now inject error message' returned exit code 127 instead of 0.
+
+sh: 1: eco: not found

--- a/tests/regression/err_messages/output_win.md
+++ b/tests/regression/err_messages/output_win.md
@@ -1,0 +1,1 @@
+output.md


### PR DESCRIPTION
I am making a draft PR because I would want to add some documentation to the README and associated tools, but it appears to be working as intended and so I'd like feedback.

The basic idea is to allow for users to optionally specify an exit code the command should return. This is done by inspecting the command and if the first word starts with `-`, then the exit code that should be returned comes after. 

## Examples
Leaving with a non-zero code will do nothing (current behavior).
```
<!-- cmdrun exit 1 -->
```
Specifying an exit code that the command returns successfully builds.
```
<!-- cmdrun -0 some long command that returns 0 if successful -->
```
Mis-matching exit codes will propagate an error message into the markdown to be rendered.
```
<!-- cmdrun -0 exit 1 -->
```