### PR TITLE
fix: fix the README's grep command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You also have to activate the preprocessor, put this in your `book.toml` file:
 > :warning: This preprocessor presents a security risk, as arbitrary commands can be run. Be careful with the commands you run.
 > To list all the commands that will be run within an mdbook, you can run the following command:
 > ```sh
-> grep -r '<!-- cmdrun' . | sed 's/.*<!-- cmdrun \(.*\) -->.*/\1/'
+> grep -r '<!--\s*cmdrun' . | sed 's/.*<!--\s*cmdrun \(.*\) -->.*/\1/'
 > ``````
 
 


### PR DESCRIPTION
I believe `mdbook-cmdrun` accepts an arbitrary number of spaces in the processed HTML comments, before the `cmdrun` command:

https://github.com/FauconFan/mdbook-cmdrun/blob/b3f424819646b8a6ff1c6cdfc566092a4b0e56e5/src/cmdrun.rs#L23-L28

However, the grep command provided in the README would ignore commands with zero or multiple spaces; this PR proposes to grep for zero or more whitespace characters instead.