### PR TITLE
treat all non-zero exit status as error

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,15 @@ The following is valid:
 
 <!-- cmdrun python3 generate_table.py -->
 
+Commands that are allowed to exit with a non-zero status should be appended with `|| true`
+so that cmdrun knows that it is intentional.
+
 ```rust
-<!-- cmdrun cat program.rs -->
+<!-- cmdrun cat program.rs || true -->
 ```
 
 ```diff
-<!-- cmdrun diff a.rs b.rs -->
+<!-- cmdrun diff a.rs b.rs || true -->
 ```
 
 ```console

--- a/src/cmdrun.rs
+++ b/src/cmdrun.rs
@@ -172,7 +172,13 @@ impl CmdRun {
         // eprintln!("command: {}", command);
         // eprintln!("stdout: {:?}", stdout);
         // eprintln!("stderr: {:?}", stderr);
-
-        Ok(stdout)
+        match output.status.code() {
+            None => Ok(format!("**cmdrun error**: '{command}' was ended before completing.")),
+            Some(0) => Ok(stdout),
+            Some(code) => {
+                Ok(format!("**cmdrun error**: The following command returned a nonzero exit code ({0}):\n\n $ {1}\n\nIf you don't consider it a failure, consider making it return 0 instead.\nFor example, by appending ` || true`.\n\nstdout (what would be put into book):\n```\n{2}\n```\nstderr (helpful for debugging):\n```\n{3}\n```",
+                code, command, String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr)))
+            }
+        }
     }
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -73,6 +73,7 @@ fn check_all_regressions_dirs() {
         entries,
         vec![
             "bash_call",
+            "err_messages",
             "inline_call",
             "py_factorial",
             "py_fibonacci",
@@ -90,3 +91,4 @@ add_dir!(py_factorial);
 add_dir!(py_fibonacci);
 add_dir!(rust_call);
 add_dir!(shell);
+add_dir!(err_messages);

--- a/tests/regression/err_messages/a.rs
+++ b/tests/regression/err_messages/a.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("I'm from `a.rs`");
+}

--- a/tests/regression/err_messages/b.rs
+++ b/tests/regression/err_messages/b.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("I'm from `b.rs`");
+}

--- a/tests/regression/err_messages/input.md
+++ b/tests/regression/err_messages/input.md
@@ -1,0 +1,7 @@
+# Error Messages
+
+The output of a helpful command that returns 1 and I would still like its output.
+<!-- cmdrun diff a.rs b.rs -->
+
+The output from a simple typo that I need to correct.
+<!-- cmdrun eco simple typo -->

--- a/tests/regression/err_messages/input_win.md
+++ b/tests/regression/err_messages/input_win.md
@@ -1,0 +1,1 @@
+input.md

--- a/tests/regression/err_messages/output.md
+++ b/tests/regression/err_messages/output.md
@@ -1,0 +1,39 @@
+# Error Messages
+
+The output of a helpful command that returns 1 and I would still like its output.
+**cmdrun error**: The following command returned a nonzero exit code (1):
+
+ $ diff a.rs b.rs 
+
+If you don't consider it a failure, consider making it return 0 instead.
+For example, by appending ` || true`.
+
+stdout (what would be put into book):
+```
+2c2
+<     println!("I'm from `a.rs`");
+---
+>     println!("I'm from `b.rs`");
+
+```
+stderr (helpful for debugging):
+```
+
+```
+The output from a simple typo that I need to correct.
+**cmdrun error**: The following command returned a nonzero exit code (127):
+
+ $ eco simple typo 
+
+If you don't consider it a failure, consider making it return 0 instead.
+For example, by appending ` || true`.
+
+stdout (what would be put into book):
+```
+
+```
+stderr (helpful for debugging):
+```
+sh: 1: eco: not found
+
+```

--- a/tests/regression/err_messages/output_win.md
+++ b/tests/regression/err_messages/output_win.md
@@ -1,0 +1,1 @@
+output.md

--- a/tests/regression/py_readme/input.md
+++ b/tests/regression/py_readme/input.md
@@ -7,11 +7,11 @@
 <!-- cmdrun python3 generate_table.py -->
 
 ```rust
-<!-- cmdrun cat program.rs -->
+<!-- cmdrun cat program.rs || true -->
 ```
 
 ```diff
-<!-- cmdrun diff a.rs b.rs -->
+<!-- cmdrun diff a.rs b.rs || true -->
 ```
 
 ```console


### PR DESCRIPTION
This is an alternative solution to #19 and resolves #18 .

Instead of introducing new (perhaps clunky) syntax, `cmdrun` just treats all non-zero exit codes as errors and injects a markdown message into the book describing this to the user. Simply appending `|| true` (like in the `diff` example) can inform `cmdrun` that your command is intentional and should be allowed to produce output for the book.